### PR TITLE
Add script to install eigensoft

### DIFF
--- a/eigensoftInstall.sh
+++ b/eigensoftInstall.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+. /shared/spack/share/spack/setup-env.sh
+
+# This line is a point of failure if multiple versions of either gsl or
+# openblas are installed for some reason.
+spack load gsl openblas
+
+# The paths for the dependencies must be added to PATH environment variables so
+# that the compiler can properly find them. It's not clear why this doesn't
+# happen by default in Spack, but doing it this way allows the software to be
+# set up. If this isn't done, the build process complains about missing
+# libraries and/or files when it tries to compile Eigensoft.
+DEPENDENCIES=("gsl" "openblas")
+for dep in "${DEPENDENCIES[@]}"; do
+    locationLine=($(spack find -p "$dep" | grep "$dep"))
+    depLocation="${locationLine[1]}"
+    libLocation="${depLocation}/lib"
+    incLocation="${depLocation}/include"
+    export LIBRARY_PATH="$libLocation:$LIBRARY_PATH"
+    export C_INCLUDE_PATH="$incLocation:$C_INCLUDE_PATH"
+done
+
+git clone https://github.com/DReichLab/EIG.git
+
+cd EIG/src
+
+make
+make install


### PR DESCRIPTION
This PR is meant to close the loop on installing Eigensoft. I figured out how to get to work by doing this manually, and now the install process is set up in this script. This is the concrete output of the troubleshooting outlined in our [HUIT Open OnDemand Internal Docs](https://docs.google.com/document/d/1gaj8l6S2nlEapImIwmib4y7zH0b3pueWE_Q7DWmWRFY/edit#heading=h.fe3qu7lefqm) document, so between the script and that description, it should make sense what's happening here.