### PR TITLE
Add slurm reporting notebook

### DIFF
--- a/slurm_reporting.ipynb
+++ b/slurm_reporting.ipynb
@@ -1,0 +1,714 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "1b66a10e-9aa6-4ac7-8cda-95b5865d94b2",
+   "metadata": {},
+   "source": [
+    "# Get stats from `sacct` and parse them\n",
+    "\n",
+    "This notebook does both the collecting of data from sacct (which can take a while) and the analysis of the data. Skip the data collection if the last run is reasonably complete so you can get to the analysis faster."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "25d42ae1-fc1b-437e-9d8c-71e40c60c0b6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "from matplotlib import pyplot as plt\n",
+    "\n",
+    "import re\n",
+    "import subprocess\n",
+    "from datetime import datetime, timedelta"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2ccfaf28-0a18-45cf-a681-38f8d4f33d06",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Keep these values the same if you aren't getting new sacct data\n",
+    "START_DATE = datetime(2024,9,1)\n",
+    "END_DATE = datetime(2025,2,18)\n",
+    "filename = f'/shared/courseSharedFolders/135510outer/135510/sacctData/{START_DATE.strftime(\"%Y-%m-%d\")}_to_{END_DATE.strftime(\"%Y-%m-%d\")}.txt'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c1de3f10-4ba3-4f47-ac65-bdba56d8b504",
+   "metadata": {},
+   "source": [
+    "## Data collection\n",
+    "\n",
+    "Skip this cell to not get new data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9fb584dc-814a-42bd-a181-95342189a095",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "output = subprocess.run(['sacct', '-XPa', '--delimiter', '`', '-o', 'ALL', '-S', START_DATE.strftime(\"%Y-%m-%d\"), '-E', END_DATE.strftime(\"%Y-%m-%d\")], capture_output=True)\n",
+    "with open(filename, 'wb') as fp:\n",
+    "    fp.write(output.stdout)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "645a0d8f-2927-4acc-8aa8-8f1eef21cbdd",
+   "metadata": {},
+   "source": [
+    "## Data cleanup\n",
+    "\n",
+    "There can be some funky issues with the data. This cleans them up."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c335c2a2-428f-4b38-b3c0-b4873e11f1ad",
+   "metadata": {},
+   "source": [
+    "### Fix newlines\n",
+    "\n",
+    "There can be issues with newlines in the SubmitLine column. This section fixes those before loading the data so that the columns don't get messed up."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "34d3d95b-0a69-4beb-aa1e-ee63b3b052d2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def fix_newlines_in_rows(input_file_path, output_file_path, correct_backtick_count=2):\n",
+    "    \"\"\"\n",
+    "    Function generated with GPT 4o\n",
+    "\n",
+    "    The idea is to fix newlines in the SubmitLine column, which contains user input that isn't \n",
+    "    restricted to a certain character set. It can use pipe characters, but I have yet to see \n",
+    "    backticks in a submitline, so those are used as separators. This function checks to see if \n",
+    "    there's the expected number of backticks in a row of the file, and if there isn't, it \n",
+    "    appends the next line to the line that has the wrong number of backticks. Whatever it \n",
+    "    modifies is printed out to the console.\n",
+    "    \"\"\"\n",
+    "    with open(input_file_path, 'r') as file:\n",
+    "        lines = file.readlines()\n",
+    "\n",
+    "    processed_lines = []\n",
+    "    i = 0\n",
+    "    while i < len(lines):\n",
+    "        line = lines[i].rstrip('\\n')\n",
+    "        actual_backtick_count = line.count('`')\n",
+    "        \n",
+    "        # Check if the current line has the correct number of backticks\n",
+    "        if actual_backtick_count != correct_backtick_count:\n",
+    "            # If not, attempt to append the next line, if available\n",
+    "            if i + 1 < len(lines):\n",
+    "                line += ' ' + lines[i + 1].rstrip('\\n')  # Appending the next line\n",
+    "                print(f\"fixed line, now reads {line}\\n\")\n",
+    "                i += 1  # Skip the next line as it has been appended\n",
+    "            \n",
+    "        processed_lines.append(line)\n",
+    "        i += 1\n",
+    "\n",
+    "    # Optionally write the processed lines to an output file\n",
+    "    with open(output_file_path, 'w') as file:\n",
+    "        for line in processed_lines:\n",
+    "            file.write(line + '\\n')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bb7d46d6-3e83-401a-9f31-adbdc2cbb217",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fixed_filename = filename.replace(\".txt\", \"_fixed.txt\")\n",
+    "fix_newlines_in_rows(filename, fixed_filename, correct_backtick_count=111)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2beadf72-4208-4a9d-8d66-05e424230f54",
+   "metadata": {},
+   "source": [
+    "### Load data into Pandas"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "02e799c6-97d4-4d0c-bb5e-f49043c05954",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.read_csv(fixed_filename, sep=\"`\")\n",
+    "len(df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6bd820df-dafa-4a62-af03-fccd9602869e",
+   "metadata": {},
+   "source": [
+    "### Add columns\n",
+    "\n",
+    "Add derived columns with start and end times as `datetime` objects, as well as time in hours on jobs, and cpu hours on jobs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "783e6c6d-2e9f-4a4a-9f28-5d4e7b4eee14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def make_datetime(dt):\n",
+    "    if pd.isnull(dt):\n",
+    "        return np.nan\n",
+    "    elif dt == \"Unknown\":\n",
+    "        return np.nan\n",
+    "    else:\n",
+    "        try:\n",
+    "            return datetime.strptime(dt, \"%Y-%m-%dT%H:%M:%S\")\n",
+    "        except Exception as e:\n",
+    "            print(e)\n",
+    "            return np.nan"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "438b55d8-0a1a-4ee5-8812-c63d7c0d72ed",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# df['startDT'] = df.Start.apply(lambda x: datetime.strptime(x, \"%Y-%m-%dT%H:%M:%S\") if not pd.isnull(x) else np.nan)\n",
+    "df['startDT'] = df.Start.apply(make_datetime)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "55fbe5c3-553f-4ae4-b8de-73179e3df9a8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# df['endDT'] = df.End.apply(lambda x: datetime.strptime(x, \"%Y-%m-%dT%H:%M:%S\") if not pd.isnull(x) or x != \"Unknown\" else np.nan)\n",
+    "df['endDT'] = df.End.apply(make_datetime)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bca4c950-ae1a-4748-93f1-6ee5c54f2870",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df['elapsedHours'] = df.ElapsedRaw.astype(float) / 3600\n",
+    "df.elapsedHours"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "84c246da-9b3b-400e-a4fb-4100d5e48b4c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df['cpuHours'] = df.elapsedHours * df.ReqCPUS\n",
+    "df.cpuHours"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b20cc2ec-bb22-47bd-924f-211e90b7604d",
+   "metadata": {},
+   "source": [
+    "### Node event time series\n",
+    "\n",
+    "To track cluster capacity, this section creates a new `timeline` dataframe to hold info on events corresponding to the start and end of jobs, as well as the number of jobs running and nodes active in the cluster as a whole and the partition."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "70ea20a9-1da3-4e16-84ab-d43692ada75b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def mixrange(s):\n",
+    "    \"\"\"\n",
+    "    Taken from stackoverflow:\n",
+    "    https://stackoverflow.com/a/18759797\n",
+    "    \"\"\"\n",
+    "    r = []\n",
+    "    for i in s.split(','):\n",
+    "        if '-' not in i:\n",
+    "            r.append(int(i))\n",
+    "        else:\n",
+    "            l,h = map(int, i.split('-'))\n",
+    "            r+= range(l,h+1)\n",
+    "    return r"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a2e1ae7c-0957-4400-92c4-4b36162458ef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def expandNodeList(x):\n",
+    "    if re.match(r'.*\\[[0-9,-]+\\]', x):\n",
+    "        #do some stuff\n",
+    "        prefix, theRange = re.findall(r'(.*)\\[([0-9,-]+)\\]', x)[0]\n",
+    "        return [f'{prefix}{x}' for x in mixrange(theRange)]\n",
+    "    else:\n",
+    "        return [x]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4ebbd074-b8d9-4e88-bb36-99ac75954857",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Expand nodes into separate rows\n",
+    "exploded = df.assign(node=df['NodeList'].apply(expandNodeList)).explode('node').drop(columns='NodeList')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "717211aa-105f-4ee1-91a0-3ec970225a08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a sequence of events\n",
+    "node_usage = []"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "000ffdd3-593e-4166-860c-5c50567b217c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for _, row in exploded.iterrows():\n",
+    "    start_event = {\n",
+    "        \"type\": \"start\",\n",
+    "        \"dt\": row['startDT'],\n",
+    "        \"node\": row[\"node\"],\n",
+    "        \"partition\": row[\"Partition\"],\n",
+    "        \"jobId\": row[\"JobID\"]\n",
+    "    }\n",
+    "    end_event = start_event.copy()\n",
+    "    end_event.update({\"type\": \"end\", \"dt\": row['endDT']})\n",
+    "    node_usage.extend([start_event, end_event])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fd8df850-9068-495d-9265-729da4b7e41e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "timeline = pd.DataFrame(node_usage)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "93d61c9f-d7c2-4513-91b9-b78c9cdf0abf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "timeline.sort_values('dt', inplace=True)\n",
+    "timeline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ba04136a-b592-495b-ab51-ee230a59539b",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "nodeCounts = {}\n",
+    "for partition in timeline.partition.unique():\n",
+    "    nodeCounts[partition] = {}\n",
+    "    for node in timeline[timeline.partition == partition].node.unique():\n",
+    "        nodeCounts[partition][node] = 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "34548387-19f7-4700-9566-7057ab4e22e8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "timeline['nodeJobsRunning'] = 0\n",
+    "timeline['partitionJobsRunning'] = 0\n",
+    "timeline['totalJobsRunning'] = 0\n",
+    "timeline['nodesActive'] = 0\n",
+    "timeline['partitionNodesActive'] = 0\n",
+    "timeline.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8b36d3e0-07a4-4f6d-a439-c035d2c5e030",
+   "metadata": {},
+   "source": [
+    "**Side note: How the counts work**\n",
+    "\n",
+    "The idea here is to iteratively use start and stop events to build counts for how many nodes are active at one time, and how many jobs are running on each node. There's a dict outside of the counting loop where counts are tracked as the timeline dataframe is iterated through, so that each event can get an accurate count. That dict is nested like `nodeCount[partition][node]`.\n",
+    "\n",
+    "To get the number of jobs running in a partition, and to get the number of active nodes within a partition, I use some nested comprehensions to keep the calculation on one line. These are the proof of concept bits that showed me that I could make this work."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1e9a9d37-fff2-4737-92d0-21ed452da1e0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test = {'general': {'g1': 2, 'g2': 0}, 'gpu': {'gpu1': 2, 'gpu2': 5}}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "712fd637-b200-4888-b2ed-4791221d8e70",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sum(sum(v.values()) for v in test.values())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0edb38a3-fc33-4789-bea4-07e3356a4575",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sum(sum([x > 0 for x in v.values()]) for v in test.values())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aaccbaf8-0ac8-44b4-ab87-fa95e69bc45b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This is where everything comes together to create the timeline of job events.\n",
+    "for i, row in timeline.iterrows():\n",
+    "    # For a start event, increment counts in dicts\n",
+    "    if row['type'] == 'start':\n",
+    "        nodeCounts[row['partition']][row['node']] += 1\n",
+    "\n",
+    "    # For an end event, decrement counts in dicts\n",
+    "    elif row['type'] == 'end':\n",
+    "        nodeCounts[row['partition']][row['node']] -= 1\n",
+    "\n",
+    "    # Get values to set in row\n",
+    "    nodeJobsRunning = nodeCounts[row['partition']][row['node']]\n",
+    "    partitionJobsRunning = sum(v for v in nodeCounts[row['partition']].values())\n",
+    "    partitionNodes = sum(v > 0 for v in nodeCounts[row['partition']].values())\n",
+    "    # Sum of all of the job counts for all nodes\n",
+    "    totalJobs = sum(sum(v.values()) for v in nodeCounts.values())\n",
+    "    # Count of all nodes with a job count greater than 0\n",
+    "    totalNodes = sum(sum([x > 0 for x in v.values()]) for v in nodeCounts.values())\n",
+    "\n",
+    "    # Set the values in the row\n",
+    "    timeline.at[i, 'nodeJobsRunning'] = nodeJobsRunning\n",
+    "    timeline.at[i, 'partitionJobsRunning'] = partitionJobsRunning\n",
+    "    timeline.at[i, 'totalJobsRunning'] = totalJobs\n",
+    "    timeline.at[i, 'nodesActive'] = totalNodes\n",
+    "    timeline.at[i, 'partitionNodesActive'] = partitionNodes\n",
+    "timeline.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "817deaf6-9206-4c48-adc9-c607ca48ff68",
+   "metadata": {},
+   "source": [
+    "## Data analysis\n",
+    "\n",
+    "Take the cleaned up data and analyze it.\n",
+    "\n",
+    "Questions to answer:\n",
+    "- How many hours have nodes been running?\n",
+    "- What's the total usage?\n",
+    "- Who have been the top users, and how much have they been using the system?\n",
+    "  - Why is their job use high? Lots of jobs, long-running interactive jobs?\n",
+    "- Are we hitting a ceiling for node usage? (for each partition)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d655c56c-09ed-404a-93ed-8ac703407b1b",
+   "metadata": {},
+   "source": [
+    "### Overall stats to report up"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4ed60bec-49ec-4bbc-8aa3-329b894ab8c3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f'Total users: {len(df.User.unique())}')\n",
+    "print(f'Total hours of use: {df.elapsedHours.sum():,.2f}')\n",
+    "print(f'Total CPU hours: {df.cpuHours.sum():,.2f} (job hours * CPUs per job)')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "77814bb7-d0bf-4aa0-b8e0-5960dc512d83",
+   "metadata": {},
+   "source": [
+    "### Node occupancy\n",
+    "\n",
+    "This gives an overview of whether node caps are being hit in the time frame under question, and provides an interface for generating a line graph showing node usage."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4094db3f-4ffa-4aec-b73b-904db8f25bd6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "partitionCaps = {\n",
+    "    'general': 75,\n",
+    "    'gpu': 75,\n",
+    "    'desktop': 50,\n",
+    "    'gpu-parallel': 20\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1ab8567c-d0cc-4a24-bb19-38d769c1e241",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for partition, cap in partitionCaps.items():\n",
+    "    maximumActiveNodes = timeline[timeline.partition == partition].partitionNodesActive.max()\n",
+    "    print(f\"In the `{partition}` queue, the maximum active nodes was {maximumActiveNodes}/{cap}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "409c333c-ba6c-4478-9b63-8ecec7c12dd2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# General queue occupancy over time\n",
+    "\n",
+    "start_dt = datetime(2025,1,1)\n",
+    "end_dt = datetime.now()\n",
+    "queue = 'general'\n",
+    "\n",
+    "# Display line graph showing that activity\n",
+    "timeline[(timeline.dt >= start_dt) & (timeline.dt <= end_dt) & (timeline.partition == queue)].plot.line(x='dt', y='partitionNodesActive', figsize=(16,9))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "37429e42-ad5d-4fde-a84d-e7d1d1f83738",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# GPU queue occupancy over time\n",
+    "\n",
+    "start_dt = datetime(2025,1,1)\n",
+    "end_dt = datetime.now()\n",
+    "queue = 'gpu'\n",
+    "\n",
+    "# Display line graph showing that activity\n",
+    "timeline[(timeline.dt >= start_dt) & (timeline.dt <= end_dt) & (timeline.partition == queue)].plot.line(x='dt', y='partitionNodesActive', figsize=(16,9))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d03be491-f87b-4562-a991-d806ec0fde1f",
+   "metadata": {},
+   "source": [
+    "### Usage by user\n",
+    "\n",
+    "Check for out of the ordinary usage over a range of time. The first set of bar charts show the usage across the whole dataset collected from Slurm accounting."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "726853c0-c57b-44a4-aa95-5f0ad0bda91b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "userUsage = df.pivot_table(values='cpuHours', index='User', columns='Partition', aggfunc='sum')\n",
+    "\n",
+    "for partition in df.Partition.unique():\n",
+    "    partitionUsage = userUsage.sort_values(by=partition, ascending=False)\n",
+    "    ax = plt.subplot()\n",
+    "    plt.barh(y=partitionUsage.head(10).index, width=partitionUsage.head(10)[partition])\n",
+    "    plt.title(f\"`{partition}` usage since {START_DATE.strftime('%B %-d, %Y')}\")\n",
+    "    plt.xlabel('CPU Hours')\n",
+    "    plt.ylabel('Top 10 Users')\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0b78aafd-9bc7-4590-84bb-a46330b946a1",
+   "metadata": {},
+   "source": [
+    "#### Usage since start of term\n",
+    "\n",
+    "This shows the usage since the start of term, assuming that the `startOfTerm` date is up to date."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aac954bb-88a3-4001-b487-9d68bd89f9fa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "startOfTerm = datetime(2025,1,1)\n",
+    "\n",
+    "timeBound = df[df.startDT >= startOfTerm]\n",
+    "userUsage = timeBound.pivot_table(values='cpuHours', index='User', columns='Partition', aggfunc='sum')\n",
+    "\n",
+    "for partition in timeBound.Partition.unique():\n",
+    "    partitionUsage = userUsage.sort_values(by=partition, ascending=False)\n",
+    "    ax = plt.subplot()\n",
+    "    plt.barh(y=partitionUsage.head(10).index, width=partitionUsage.head(10)[partition])\n",
+    "    plt.title(f\"`{partition}` usage since {startOfTerm.strftime('%B %-d, %Y')}\")\n",
+    "    plt.xlabel('CPU Hours')\n",
+    "    plt.ylabel('Top 10 Users')\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f90b6467-d8db-4058-8aba-4a11da9cb051",
+   "metadata": {},
+   "source": [
+    "#### Usage in past month\n",
+    "\n",
+    "Technically, usage in the 30 days prior to the end date of the dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ebd52003-2889-4c1b-917f-b6dcc53f632e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "oneMonthAgo = END_DATE - timedelta(days=30)\n",
+    "\n",
+    "timeBound = df[df.startDT >= oneMonthAgo]\n",
+    "userUsage = timeBound.pivot_table(values='cpuHours', index='User', columns='Partition', aggfunc='sum')\n",
+    "\n",
+    "for partition in timeBound.Partition.unique():\n",
+    "    partitionUsage = userUsage.sort_values(by=partition, ascending=False)\n",
+    "    ax = plt.subplot()\n",
+    "    plt.barh(y=partitionUsage.head(10).index, width=partitionUsage.head(10)[partition])\n",
+    "    plt.title(f\"`{partition}` usage since {oneMonthAgo.strftime('%B %-d, %Y')}\")\n",
+    "    plt.xlabel('CPU Hours')\n",
+    "    plt.ylabel('Top 10 Users')\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3d68ef90-6005-4b77-add0-8e106c297871",
+   "metadata": {},
+   "source": [
+    "#### Usage in past week\n",
+    "\n",
+    "Technically usage in the 7 days prior to the end date of the data collected"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c9b6f891-3e8d-4f91-b71e-dc5d3f40f7a3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "oneWeekAgo = END_DATE - timedelta(days=7)\n",
+    "\n",
+    "timeBound = df[df.startDT >= oneWeekAgo]\n",
+    "userUsage = timeBound.pivot_table(values='cpuHours', index='User', columns='Partition', aggfunc='sum')\n",
+    "\n",
+    "for partition in timeBound.Partition.unique():\n",
+    "    partitionUsage = userUsage.sort_values(by=partition, ascending=False)\n",
+    "    ax = plt.subplot()\n",
+    "    plt.barh(y=partitionUsage.head(10).index, width=partitionUsage.head(10)[partition])\n",
+    "    plt.title(f\"`{partition}` usage since {oneWeekAgo.strftime('%B %-d, %Y')}\")\n",
+    "    plt.xlabel('CPU Hours')\n",
+    "    plt.ylabel('Top 10 Users')\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e084796c-8595-4f6a-9752-da0ef555ffeb",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
# Overview

This adds a slurm accounting notebook for use in reporting on OOD usage. The intent is to provide a way to keep tabs on OOD usage and identify outliers in usage that should be addressed. The notebook can be run on OOD from a generic Jupyter environment that runs directly on a compute node (e.g. spack or spack-conda) instead of in a container, where it doesn't have access to slurm commands like `sacct`.

The notebook can collect data from `sacct`, or that can be skipped to look at data that has already been collected. In production, there's a copy of this notebook in the shared folder for the HUIT OOD test course, and it can be run as a regular user from there. We may want to set up an ILE of convenience to share this file in the future, in case any curious guests mess with it, but we can add that complexity when we need it.
